### PR TITLE
* Cached items now won't have their cached properties JSON serialized…

### DIFF
--- a/src/main/java/org/craftercms/core/cache/impl/CacheRefresherImpl.java
+++ b/src/main/java/org/craftercms/core/cache/impl/CacheRefresherImpl.java
@@ -70,7 +70,7 @@ public class CacheRefresherImpl implements CacheRefresher {
             try {
                 refreshItem(item, cache);
             } catch (Exception ex) {
-                logger.error("Refresh for " + item + " failed", ex);
+                logger.error("Refresh for " + getScopeAndKeyString(item) + " failed", ex);
             }
         }
     }
@@ -86,21 +86,25 @@ public class CacheRefresherImpl implements CacheRefresher {
         Object[] loaderParams = item.getLoaderParams();
 
         if (loader == null) {
-            throw new InternalCacheEngineException("No cache loader for " + item);
+            throw new InternalCacheEngineException("No cache loader for " + getScopeAndKeyString(item));
         }
 
         if (logger.isDebugEnabled()) {
-            logger.debug("Refreshing " + item);
+            logger.debug("Refreshing " + getScopeAndKeyString(item));
         }
 
         Object newValue = loader.load(loaderParams);
         if (newValue != null) {
             cache.put(item.getScope(), item.getKey(), newValue, item.getDependencyKeys(), item.getTicksToExpire(),
-                item.getTicksToRefresh(), item.getLoader(), item.getLoaderParams());
+                      item.getTicksToRefresh(), item.getLoader(), item.getLoaderParams());
         } else {
             // If newValue returned is null, remove the item from the cache
             cache.remove(item.getScope(), item.getKey());
         }
+    }
+
+    protected String getScopeAndKeyString(CacheItem item) {
+        return "[scope='" + item.getScope() + "', key=" + item.getKey() + "]";
     }
 
 }

--- a/src/main/java/org/craftercms/core/controller/rest/RestControllerBase.java
+++ b/src/main/java/org/craftercms/core/controller/rest/RestControllerBase.java
@@ -16,7 +16,7 @@
  */
 package org.craftercms.core.controller.rest;
 
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 
@@ -68,10 +68,7 @@ public class RestControllerBase {
     }
 
     protected Map<String, Object> createSingletonModel(String attributeName, Object attributeValue) {
-        Map<String, Object> model = new HashMap<>(1);
-        model.put(attributeName, attributeValue);
-
-        return model;
+        return Collections.singletonMap(attributeName, attributeValue);
     }
 
 }

--- a/src/main/java/org/craftercms/core/util/cache/impl/CachingAwareObjectBase.java
+++ b/src/main/java/org/craftercms/core/util/cache/impl/CachingAwareObjectBase.java
@@ -16,6 +16,8 @@
  */
 package org.craftercms.core.util.cache.impl;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -50,16 +52,19 @@ public abstract class CachingAwareObjectBase implements CachingAwareObject {
         }
     }
 
+    @JsonIgnore
     @Override
     public String getScope() {
         return scope;
     }
 
+    @JsonIgnore
     @Override
     public void setScope(String scope) {
         this.scope = scope;
     }
 
+    @JsonIgnore
     @Override
     public Object getKey() {
         return key;
@@ -70,11 +75,13 @@ public abstract class CachingAwareObjectBase implements CachingAwareObject {
         this.key = key;
     }
 
+    @JsonIgnore
     @Override
     public List<Object> getDependencyKeys() {
         return dependencyKeys;
     }
 
+    @JsonIgnore
     @Override
     public void setDependencyKeys(List<Object> dependencyKeys) {
         this.dependencyKeys = dependencyKeys;
@@ -116,11 +123,13 @@ public abstract class CachingAwareObjectBase implements CachingAwareObject {
         }
     }
 
+    @JsonIgnore
     @Override
     public Long getCachingTime() {
         return cachingTime;
     }
 
+    @JsonIgnore
     @Override
     public void setCachingTime(Long cachingTime) {
         this.cachingTime = cachingTime;

--- a/src/main/resources/crafter/core/cache-context.xml
+++ b/src/main/resources/crafter/core/cache-context.xml
@@ -31,6 +31,7 @@
     <bean id="crafter.cacheTickerJob" class="org.springframework.scheduling.quartz.MethodInvokingJobDetailFactoryBean">
         <property name="targetObject" ref="crafter.cache"/>
         <property name="targetMethod" value="tick"/>
+        <property name="concurrent" value="false"/>
     </bean>
 
     <bean id="crafter.cacheTickerTrigger" class="org.springframework.scheduling.quartz.SimpleTriggerFactoryBean">


### PR DESCRIPTION
… (in XML they where already ignored).

* Added concurrent = false to the cache ticker job so several jobs don't run concurrently (which shouldn't happen already since the thread count is 1, but just in case...)