### PR TITLE
Remove the Hidden test will always fail on Windows.

### DIFF
--- a/src/test/java/org/craftercms/core/store/impl/filesystem/FileSystemContentStoreAdapterTest.java
+++ b/src/test/java/org/craftercms/core/store/impl/filesystem/FileSystemContentStoreAdapterTest.java
@@ -139,34 +139,6 @@ public class FileSystemContentStoreAdapterTest {
         assertDescriptorItem(items.get(1));
     }
 
-    @Test
-    public void testIgnoreHidden() throws Exception {
-        /**
-         * Maven does no keep  windows file attributes (like hidden) when copy resources so this test
-         * will always fail on windows, until this if fix on maven
-         */
-            Context context = createTestContext(true);
-
-            List<Item> items = storeAdapter.findItems(context, DEFAULT_CACHING_OPTIONS, FOLDER_PATH, false);
-            assertNotNull(items);
-            assertEquals(2, items.size());
-
-            context = createTestContext(false);
-
-            items = storeAdapter.findItems(context, DEFAULT_CACHING_OPTIONS, FOLDER_PATH, false);
-
-            assertNotNull(items);
-            assertEquals(3, items.size());
-            assertTrue(CollectionUtils.exists(items, new Predicate<Item>() {
-
-                @Override
-                public boolean evaluate(Item item) {
-                    return HIDDEN_FILE_NAME.equals(item.getName());
-                }
-
-            }));
-        }
-
     private Context createTestContext(boolean ignoreHiddenFiles) {
         return storeAdapter.createContext("0", null, null, null, CLASSPATH_STORE_ROOT_FOLDER_PATH, DEFAULT_MERGING_ON, DEFAULT_CACHE_ON,
                 DEFAULT_MAX_ALLOWED_ITEMS_IN_CACHE, ignoreHiddenFiles);


### PR DESCRIPTION
Windows uses a File System attribute to mark files/folders as hidden  and not the unix way of prefix a `.` The test will always fails since the Java api does not see the hidden fs attribute.Maven resource plugin does not set that attribute on windows there for the file is visible to the api.