### PR TITLE
Include processor now doesn't delete the include element:

### DIFF
--- a/src/main/java/org/craftercms/core/processors/impl/IncludeDescriptorsProcessor.java
+++ b/src/main/java/org/craftercms/core/processors/impl/IncludeDescriptorsProcessor.java
@@ -38,8 +38,8 @@ import org.dom4j.Node;
 import org.springframework.beans.factory.annotation.Required;
 
 /**
- * {@link org.craftercms.core.processors.ItemProcessor} that replaces special "include" tags found in a descriptor
- * document with the document tree of descriptors specified in these "include" tags.
+ * {@link org.craftercms.core.processors.ItemProcessor} that finds special "include" tags found in a descriptor
+ * document and inserts there the document tree of descriptors specified in these "include" tags.
  *
  * @author Sumer Jabri
  * @author Alfonso Vásquez
@@ -54,6 +54,10 @@ public class IncludeDescriptorsProcessor implements ItemProcessor {
      * XPath query for the include element.
      */
     protected String includeElementXPathQuery;
+    /**
+     * Flag to indicate if the include element should be removed (false by default).
+     */
+    protected boolean removeIncludeElement;
     /**
      * XPath query relative to include elements for nodes tha specify if the include is disabled or not.
      */
@@ -73,6 +77,13 @@ public class IncludeDescriptorsProcessor implements ItemProcessor {
     @Required
     public void setIncludeElementXPathQuery(String includeElementXPathQuery) {
         this.includeElementXPathQuery = includeElementXPathQuery;
+    }
+
+    /**
+     * Sets the flag to indicate if the include element should be removed (false by default).
+     */
+    public void setRemoveIncludeElement(boolean removeIncludeElement) {
+        this.removeIncludeElement = removeIncludeElement;
     }
 
     /**
@@ -185,10 +196,15 @@ public class IncludeDescriptorsProcessor implements ItemProcessor {
         int includeElementIdx = includeElementParentChildren.indexOf(includeElement);
         Element itemToIncludeRootElement = itemToInclude.getDescriptorDom().getRootElement().createCopy();
 
-        // Remove the <include> element
-        includeElementParentChildren.remove(includeElementIdx);
-        // Add the item's root element
-        includeElementParentChildren.add(includeElementIdx, itemToIncludeRootElement);
+        if (removeIncludeElement) {
+            // Remove the <include> element
+            includeElementParentChildren.remove(includeElementIdx);
+            // Add the item's root element
+            includeElementParentChildren.add(includeElementIdx, itemToIncludeRootElement);
+        } else {
+            // Add the item's root element
+            includeElementParentChildren.add(includeElementIdx + 1, itemToIncludeRootElement);
+        }
 
         // Add dependency key
         item.addDependencyKey(itemToInclude.getKey());

--- a/src/test/java/org/craftercms/core/processors/impl/IncludeDescriptorsProcessorTest.java
+++ b/src/test/java/org/craftercms/core/processors/impl/IncludeDescriptorsProcessorTest.java
@@ -69,8 +69,10 @@ public class IncludeDescriptorsProcessorTest {
 
     private static final String EXPECTED_XML =      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
                                                     "<page>" +
+                                                        "<include>" + DESCRIPTOR2_URL + "</include>" +
                                                         "<component>" +
                                                             "<element>a</element>" +
+                                                            "<include>" + DESCRIPTOR3_URL + "</include>" +
                                                             "<component>" +
                                                                 "<element>b</element>" +
                                                                 "<include>" + DESCRIPTOR1_URL + "</include>" +


### PR DESCRIPTION
* The IncludeDescriptorsProcessor by default now doesn't remove the include element (needed as an extra information for re-indexed based on component updates). The old behavior can be achieved if removeIncludeElement is set to true.

Ticket craftercms/craftercms#2115