### PR TITLE
Item lists are now returned always as JSON arrays

### DIFF
--- a/src/main/java/org/craftercms/core/util/json/jackson/Dom4jDocumentJsonSerializer.java
+++ b/src/main/java/org/craftercms/core/util/json/jackson/Dom4jDocumentJsonSerializer.java
@@ -10,6 +10,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.dom4j.Attribute;
 import org.dom4j.Document;
@@ -39,6 +40,8 @@ import org.dom4j.Node;
  * @author avasquez
  */
 public class Dom4jDocumentJsonSerializer extends JsonSerializer<Document> {
+
+    public static final String ITEM_LIST_ATTRIBUTE_NAME = "item-list";
 
     public static final String TEXT_JSON_KEY = "text";
 
@@ -106,9 +109,11 @@ public class Dom4jDocumentJsonSerializer extends JsonSerializer<Document> {
                 }
             }
 
+            boolean itemList = isItemList(element);
             Map<String, List<Element>> children = getChildren(element);
+
             for (Map.Entry<String, List<Element>> entry : children.entrySet()) {
-                if (entry.getValue().size() > 1) {
+                if (itemList || entry.getValue().size() > 1) {
                     jsonGenerator.writeArrayFieldStart(entry.getKey());
 
                     for (Element child : entry.getValue()) {
@@ -132,7 +137,7 @@ public class Dom4jDocumentJsonSerializer extends JsonSerializer<Document> {
     @SuppressWarnings("unchecked")
     private List<String> getTextContentFromMixedContent(Element element) {
         List<Node> content = element.content();
-        List<String> textContent = new ArrayList<String>();
+        List<String> textContent = new ArrayList<>();
 
         for (Node node : content) {
             if (node.getNodeType() == Node.TEXT_NODE) {
@@ -163,6 +168,10 @@ public class Dom4jDocumentJsonSerializer extends JsonSerializer<Document> {
         }
 
         return groupedChildren;
+    }
+
+    private boolean isItemList(Element element) {
+        return BooleanUtils.toBoolean(element.attributeValue(ITEM_LIST_ATTRIBUTE_NAME));
     }
 
 }

--- a/src/main/java/org/craftercms/core/util/json/jackson/Dom4jDocumentJsonSerializer.java
+++ b/src/main/java/org/craftercms/core/util/json/jackson/Dom4jDocumentJsonSerializer.java
@@ -10,6 +10,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.dom4j.Attribute;
@@ -42,6 +43,7 @@ import org.dom4j.Node;
 public class Dom4jDocumentJsonSerializer extends JsonSerializer<Document> {
 
     public static final String ITEM_LIST_ATTRIBUTE_NAME = "item-list";
+    public static final String[] IGNORABLE_ATTRIBUTES = { ITEM_LIST_ATTRIBUTE_NAME };
 
     public static final String TEXT_JSON_KEY = "text";
 
@@ -72,7 +74,9 @@ public class Dom4jDocumentJsonSerializer extends JsonSerializer<Document> {
             objectStarted = true;
 
             for (Attribute attribute : attributes) {
-                jsonGenerator.writeStringField(attribute.getName(), attribute.getValue());
+                if (!ArrayUtils.contains(IGNORABLE_ATTRIBUTES, attribute.getName())) {
+                    jsonGenerator.writeStringField(attribute.getName(), attribute.getValue());
+                }
             }
         }
 


### PR DESCRIPTION
* Dom4jDocumentJsonSerializer now returns elements with item-list="true" as JSON arrays.

Ticket craftercms/craftercms#2268
