### PR TITLE
Renamed activeCache profile to crafter.core.activeCache

### DIFF
--- a/src/main/resources/crafter/core/cache-context.xml
+++ b/src/main/resources/crafter/core/cache-context.xml
@@ -45,7 +45,7 @@
 
     <!-- Cache Ticker -->
 
-    <beans profile="activeCache">
+    <beans profile="crafter.core.activeCache">
         <bean id="crafter.cacheTickerJob" class="org.springframework.scheduling.quartz.MethodInvokingJobDetailFactoryBean">
             <property name="targetObject" ref="crafter.cache"/>
             <property name="targetMethod" value="tick"/>


### PR DESCRIPTION
Renamed `activeCache` profile to `crafter.core.activeCache`, to better distinguish it from Studio's profiles.

