### PR TITLE
The DefaultCacheTemplate now does double-checked locking

### DIFF
--- a/src/main/java/org/craftercms/core/util/cache/impl/DefaultCacheTemplate.java
+++ b/src/main/java/org/craftercms/core/util/cache/impl/DefaultCacheTemplate.java
@@ -28,6 +28,9 @@ import org.craftercms.core.util.CacheUtils;
 import org.craftercms.core.util.cache.CacheTemplate;
 import org.springframework.beans.factory.annotation.Required;
 
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
 /**
  * Class description goes HERE
  *
@@ -38,6 +41,11 @@ public class DefaultCacheTemplate implements CacheTemplate {
     private static final Log logger = LogFactory.getLog(DefaultCacheTemplate.class);
 
     private CacheService cacheService;
+    private Lock lock;
+
+    public DefaultCacheTemplate() {
+        this.lock = new ReentrantLock();
+    }
 
     @Override
     public CacheService getCacheService() {
@@ -71,13 +79,22 @@ public class DefaultCacheTemplate implements CacheTemplate {
 
         T obj = doGet(context, callback, key);
         if (obj == null) {
-            obj = callback.execute();
-            if (obj != null) {
-                if (cachingOptions == null) {
-                    cachingOptions = CachingOptions.DEFAULT_CACHING_OPTIONS;
-                }
+            lock.lock();
+            try {
+                // Check again if another concurrent thread has already put the item in the cache
+                obj = doGet(context, callback, key);
+                if (obj == null) {
+                    obj = callback.execute();
+                    if (obj != null) {
+                        if (cachingOptions == null) {
+                            cachingOptions = CachingOptions.DEFAULT_CACHING_OPTIONS;
+                        }
 
-                obj = doPut(context, cachingOptions, callback, key, obj);
+                        obj = doPut(context, cachingOptions, callback, key, obj);
+                    }
+                }
+            } finally {
+                lock.unlock();
             }
         }
 

--- a/src/test/java/org/craftercms/core/util/cache/impl/DefaultCacheTemplateTest.java
+++ b/src/test/java/org/craftercms/core/util/cache/impl/DefaultCacheTemplateTest.java
@@ -31,14 +31,7 @@ import org.mockito.stubbing.Answer;
 import static org.craftercms.core.service.CachingOptions.DEFAULT_CACHING_OPTIONS;
 import static org.craftercms.core.util.CacheUtils.generateKey;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyObject;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 /**
  * Class description goes HERE
@@ -74,7 +67,7 @@ public class DefaultCacheTemplateTest {
 
         Object key = generateKey(RANDOM_KEY_ELEM);
 
-        verify(cache, times(2)).get(context, key);
+        verify(cache, atLeast(2)).get(context, key);
         verify(cache).put(eq(context), eq(key), eq(time1), eq(DEFAULT_CACHING_OPTIONS), any(CacheLoader.class));
     }
 


### PR DESCRIPTION
The DefaultCacheTemplate now does double-checked locking to avoid concurrent threads from loading the same item multiple times.