### PR TITLE
Improvement for Blob Store:

### DIFF
--- a/src/main/java/org/craftercms/core/service/impl/ContentStoreServiceImpl.java
+++ b/src/main/java/org/craftercms/core/service/impl/ContentStoreServiceImpl.java
@@ -247,7 +247,7 @@ public class ContentStoreServiceImpl extends AbstractCachedContentStoreService {
                         }
                     };
                     BlobStore store = blobStoreResolver.getById(configGetter, blob.getStoreId());
-                    return new ResourceBasedContent(store.getResource(blob));
+                    return new ResourceBasedContent(store.getResource(url, blob));
                 } catch (IOException | ConfigurationException e) {
                     throw new StoreException("Error reading blob file at " + blobUrl, e);
                 }


### PR DESCRIPTION
    - Blob files no longer contain the url of the remote file, to support cut/copy of folders

craftercms/craftercms#3744

Depends on https://github.com/craftercms/commons/pull/213
