### PR TITLE
Bugfix/6526 42x

### DIFF
--- a/src/main/resources/crafter/core/core.properties
+++ b/src/main/resources/crafter/core/core.properties
@@ -130,6 +130,8 @@ crafter.core.rest.views.json.prefixJson=false
 # True to render the single attribute of the model map as the JSON root object (when the map has only one attribute),
 # false to render the entire model map as the root object.
 crafter.core.rest.views.json.renderSingleAttributeAsRootObject=true
+# True to render attributes as properties of the JSON object, false to omit them.
+crafter.core.rest.views.json.renderAttributes=false
 # The content store URLs (comma-separated list) that are allowed to be accessed through the REST API
 crafter.core.rest.content.store.url.allowedPatterns=
 # The content store URLs (comma-separated list) that are forbidden to be accessed through the REST API

--- a/src/main/resources/crafter/core/rest-context.xml
+++ b/src/main/resources/crafter/core/rest-context.xml
@@ -51,12 +51,14 @@
 
     <!-- JSON -->
 
+    <bean id="crafter.dom4jDocumentJsonSerializer" class="org.craftercms.core.util.json.jackson.Dom4jDocumentJsonSerializer">
+        <constructor-arg name="renderAttributes" value="${crafter.core.rest.views.json.renderAttributes}"/>
+    </bean>
+
     <bean id="crafter.coreObjectMapper" class="org.craftercms.commons.jackson.CustomSerializationObjectMapper">
         <property name="serializers">
             <list>
-                <bean class="org.craftercms.core.util.json.jackson.Dom4jDocumentJsonSerializer">
-                    <constructor-arg name="renderAttributes" value="${crafter.core.rest.views.json.renderAttributes}"/>
-                </bean>
+                <ref bean="crafter.dom4jDocumentJsonSerializer"/>
             </list>
         </property>
     </bean>

--- a/src/main/resources/crafter/core/rest-context.xml
+++ b/src/main/resources/crafter/core/rest-context.xml
@@ -54,7 +54,9 @@
     <bean id="crafter.coreObjectMapper" class="org.craftercms.commons.jackson.CustomSerializationObjectMapper">
         <property name="serializers">
             <list>
-                <bean class="org.craftercms.core.util.json.jackson.Dom4jDocumentJsonSerializer"/>
+                <bean class="org.craftercms.core.util.json.jackson.Dom4jDocumentJsonSerializer">
+                    <constructor-arg name="renderAttributes" value="${crafter.core.rest.views.json.renderAttributes}"/>
+                </bean>
             </list>
         </property>
     </bean>

--- a/src/test/java/org/craftercms/core/util/json/Dom4JDocumentJsonSerializerTest.java
+++ b/src/test/java/org/craftercms/core/util/json/Dom4JDocumentJsonSerializerTest.java
@@ -39,47 +39,103 @@ import static org.junit.Assert.assertEquals;
  */
 public class Dom4JDocumentJsonSerializerTest {
 
-    public static final String XML =
-            "<root>" +
-                    "<e1 />" +
-                    "<e2>text</e2>" +
-                    "<e3 name='value' />" +
-                    "<e4 name='value'>text</e4>" +
-                    "<e5><a>text</a><b>text</b></e5>" +
-                    "<e6><a>text</a><a>text</a></e6>" +
-                    "<e7><a name='value'>text</a><a name='value'>text</a></e7>" +
-                    "<e8>text<a>text</a></e8>" +
-                    "<e9>text<a>text</a>text</e9>" +
-            "</root>";
+    private static final String XML =
+            """
+                    <root>
+                        <e1 />
+                        <e2>text</e2>
+                        <e3 name='value' />
+                        <e4 name='value'>text</e4>
+                        <e5><a>text</a><b>text</b></e5>
+                        <e6><a>text</a><a>text</a></e6>
+                        <e7><a name='value'>text</a><a name='value'>text</a></e7>
+                        <e8>text<a>text</a></e8>
+                        <e9>text<a>text</a>text</e9>
+                        <e10 item-list="true" />
+                        <e11 item-list="true">
+                            <item>
+                                <key>e11_key</key>
+                                <value>e11_value</value>
+                                <include>e11_include</include>
+                            </item>
+                        </e11>
+                        <e12 />
+                        <e13 no-default="true" />
+                        <e14 crafter-source="/site/website/crafter-level-descriptor.level.xml"
+                                crafter-source-content-type-id="/component/level-descriptor">inherited</e14>
+                    </root>""";
 
-    public static final String XML_AS_JSON =
-            "{\"root\":{" +
-                    "\"e1\":null," +
-                    "\"e2\":\"text\"," +
-                    "\"e3\":{\"name\":\"value\"}," +
-                    "\"e4\":{\"name\":\"value\",\"text\":\"text\"}," +
-                    "\"e5\":{\"a\":\"text\",\"b\":\"text\"}," +
-                    "\"e6\":{\"a\":[\"text\",\"text\"]}," +
-                    "\"e7\":{\"a\":[{\"name\":\"value\",\"text\":\"text\"},{\"name\":\"value\",\"text\":\"text\"}]}," +
-                    "\"e8\":{\"text\":\"text\",\"a\":\"text\"}," +
-                    "\"e9\":{\"text\":[\"text\",\"text\"],\"a\":\"text\"}" +
-                    "}" +
-            "}";
+    private static final String XML_AS_JSON =
+            """
+                    {
+                        "root":{
+                            "e1":null,
+                            "e2":"text",
+                            "e3":{"name":"value"},
+                            "e4":{"name":"value","text":"text"},
+                            "e5":{"a":"text","b":"text"},
+                            "e6":{"a":["text","text"]},
+                            "e7":{"a":[{"name":"value","text":"text"},{"name":"value","text":"text"}]},
+                            "e8":{"text":"text","a":"text"},
+                            "e9":{"text":["text","text"],"a":"text"},
+                            "e10":{},
+                            "e11": {
+                                "item": [
+                                    {"key": "e11_key", "value": "e11_value", "include": "e11_include"}
+                                ]
+                            },
+                            "e12":null,
+                            "e13":null,
+                            "e14": {
+                                "crafter-source": "/site/website/crafter-level-descriptor.level.xml",
+                                "crafter-source-content-type-id": "/component/level-descriptor",
+                                "text": "inherited"}
+                        }
+                    }""".replaceAll("[\\n\\t\\s]+", "");
+    private static final String XML_AS_JSON_NO_ATTRIBUTES =
+            """
+                    {
+                        "root":{
+                            "e1":null,
+                            "e2":"text",
+                            "e3":null,
+                            "e4":"text",
+                            "e5":{"a":"text","b":"text"},
+                            "e6":{"a":["text","text"]},
+                            "e7":{"a":["text","text"]},
+                            "e8":{"text":"text","a":"text"},
+                            "e9":{"text":["text","text"],"a":"text"},
+                            "e10":{},
+                            "e11": {
+                                "item": [
+                                    {"key": "e11_key", "value": "e11_value", "include": "e11_include"}
+                                ]
+                            },
+                            "e12":null,
+                            "e13":null,
+                            "e14": "inherited"
+                        }
+                    }""".replaceAll("[\\n\\t\\s]+", "");
 
     private Document document;
-    private CustomSerializationObjectMapper objectMapper;
 
     @Before
     public void setUp() throws Exception {
         setUpTestDocument();
-        setUpTestObjectMapper();
     }
 
     @Test
-    public void testSerializer() throws Exception {
-        String json = objectMapper.writeValueAsString(document);
+    public void testRenderAttributes() throws Exception {
+        String json = getTestObjectMapper(true).writeValueAsString(document);
 
         assertEquals(XML_AS_JSON, json.toString());
+    }
+
+    @Test
+    public void testNoRenderAttributes() throws Exception {
+        String json = getTestObjectMapper(false).writeValueAsString(document);
+
+        assertEquals(XML_AS_JSON_NO_ATTRIBUTES, json.toString());
     }
 
     private void setUpTestDocument() throws SAXException {
@@ -95,15 +151,16 @@ public class Dom4JDocumentJsonSerializerTest {
         }
     }
 
-    private void setUpTestObjectMapper() {
-        Dom4jDocumentJsonSerializer serializer = new Dom4jDocumentJsonSerializer();
+    private CustomSerializationObjectMapper getTestObjectMapper(boolean renderAttributes) {
+        Dom4jDocumentJsonSerializer serializer = new Dom4jDocumentJsonSerializer(renderAttributes);
         List<JsonSerializer<?>> serializers = new ArrayList<>();
 
         serializers.add(serializer);
 
-        objectMapper = new CustomSerializationObjectMapper();
+        CustomSerializationObjectMapper objectMapper = new CustomSerializationObjectMapper();
         objectMapper.setSerializers(serializers);
         objectMapper.afterPropertiesSet();
+        return objectMapper;
     }
 
 }


### PR DESCRIPTION
Do not serialize xml node attributes to JSON
Added property to provide partial backwards compatibility
Render empty xml elements as empty JSON objects when element contains attribute 'item-list=true'
https://github.com/craftercms/craftercms/issues/6526