### PR TITLE
Fix test case caused by Java21 change

### DIFF
--- a/src/test/java/org/craftercms/core/service/impl/ContentStoreServiceImplTest.java
+++ b/src/test/java/org/craftercms/core/service/impl/ContentStoreServiceImplTest.java
@@ -61,7 +61,7 @@ public class ContentStoreServiceImplTest {
     private static final String CLASSPATH_STORE_ROOT_FOLDER_PATH =
         "classpath:stores/" + ContentStoreServiceImplTest.class.getSimpleName();
 
-    private static final String ROOT_FOLDER_NAME = "";
+    private static final String ROOT_FOLDER_NAME = "ContentStoreServiceImplTest";
     private static final String ROOT_FOLDER_PATH = "/";
 
     private static final String INVALID_PATH = "no_file";


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
@sumerjabri This test case failed because the Java 21 upgrade changed how the `new File()` works: https://github.com/craftercms/core/blob/develop/src/main/java/org/craftercms/core/store/impl/filesystem/FileSystemFile.java#L40

In Java 17:
```
file = new java.io.File("/tmp/parent", "/")
```
=> This returns a new file with the ending `/`: `/tmp/parent/`. As a result `file.getName()` returns an empty string.

In Java 21:
```
file = new java.io.File("/tmp/parent", "/")
```
=> This returns a new file WITHOUT ending `/`: `/tmp/parent`. As a result, `file.getName()` return the `parent` string