### PR TITLE
New CrafterRestController annotation to allow RestControllers to have their own Exception handling

### DIFF
--- a/src/main/java/org/craftercms/core/controller/rest/CrafterRestController.java
+++ b/src/main/java/org/craftercms/core/controller/rest/CrafterRestController.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2007-2024 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.craftercms.core.controller.rest;
+
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.lang.annotation.*;
+
+/**
+ * Extension to {@link RestController} that marks a controller to
+ * be intercepted by {@link ExceptionHandlers} for exception handling.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@RestController
+@ResponseBody
+public @interface CrafterRestController {
+}

--- a/src/main/java/org/craftercms/core/controller/rest/ExceptionHandlers.java
+++ b/src/main/java/org/craftercms/core/controller/rest/ExceptionHandlers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2023 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2024 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as published by
@@ -46,7 +46,7 @@ import static org.craftercms.core.controller.rest.RestControllerBase.createRespo
  * @author avasquez
  */
 @Order
-@ControllerAdvice(annotations = RestController.class)
+@ControllerAdvice(annotations = CrafterRestController.class)
 public class ExceptionHandlers {
     public static final String RESULT_KEY_VALIDATION_ERRORS = "validationErrors";
 


### PR DESCRIPTION
https://github.com/craftersoftware/craftercms/issues/992
New CrafterRestController annotation to allow RestControllers to have their own Exception handling
